### PR TITLE
Stage 1: Validate landing screen

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,25 +1,91 @@
-import { Text, View } from "react-native";
+import { useState } from "react";
+import { Alert, KeyboardAvoidingView, Platform, ScrollView, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import { AppHeader } from "@/components/app-header";
+import { MarketSentimentCard } from "@/components/market-sentiment-card";
+import { NeuralEngineCard } from "@/components/neural-engine-card";
+import { PrimaryButton } from "@/components/primary-button";
+import { SectionCard } from "@/components/section-card";
+import { TerminalLogs } from "@/components/terminal-logs";
 
 export default function ValidateScreen() {
+  const [concept, setConcept] = useState("");
+  const [background, setBackground] = useState("");
+
+  const canSubmit = concept.trim().length > 0 && background.trim().length > 0;
+
+  function onStressTest() {
+    Alert.alert(
+      "STRESS TEST INITIATED",
+      "Backend wiring lands in stage 6 — for now this only validates the form.",
+    );
+  }
+
   return (
     <SafeAreaView edges={["top"]} className="flex-1 bg-bg">
       <AppHeader />
-      <View className="flex-1 justify-center px-6">
-        <View className="mb-4 self-start rounded-sm bg-accent px-2 py-1">
-          <Text className="font-mono text-[11px] font-semibold tracking-terminal text-bg">
-            VALIDATION ENGINE V2.4
-          </Text>
-        </View>
-        <Text className="text-5xl font-black leading-[1.05] text-ink">
-          STRESS{"\n"}TEST <Text className="text-accent">YOUR</Text>{"\n"}IDEA
-        </Text>
-        <Text className="mt-6 font-mono text-[11px] tracking-terminal text-ink-muted">
-          STAGE_0 :: SCAFFOLD_READY
-        </Text>
-      </View>
+      <KeyboardAvoidingView
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        className="flex-1"
+      >
+        <ScrollView
+          showsVerticalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
+          contentContainerStyle={{ paddingBottom: 32 }}
+        >
+          <View className="gap-5 px-5 pt-6">
+            <View className="self-start rounded-sm bg-accent px-2 py-1">
+              <Text className="font-mono text-[11px] font-semibold tracking-terminal text-bg">
+                VALIDATION ENGINE V2.4
+              </Text>
+            </View>
+
+            <Text className="text-[56px] font-black leading-[1.0] text-ink">
+              STRESS{"\n"}TEST <Text className="text-accent">YOUR</Text>
+              {"\n"}IDEA
+            </Text>
+
+            <Text className="font-sans text-[14px] leading-[20px] text-ink-muted">
+              Submit your concept to our ruthless, data-driven validation engine. We don&apos;t do
+              &quot;maybe.&quot; We do market reality.
+            </Text>
+
+            <SectionCard
+              number="01"
+              title="THE CONCEPT"
+              required
+              value={concept}
+              onChangeText={setConcept}
+              placeholder="Describe your project idea in detail. What problem does it solve? Who is the target user? How does it generate value?"
+              minHeight={110}
+            />
+
+            <SectionCard
+              number="02"
+              title="FOUNDER BACKGROUND"
+              required
+              value={background}
+              onChangeText={setBackground}
+              placeholder="Tell us why you are the right person to build this. Previous experience, unique insights, and available resources."
+              minHeight={110}
+            />
+
+            <PrimaryButton
+              label="STRESS TEST THIS"
+              icon="flash"
+              disabled={!canSubmit}
+              onPress={onStressTest}
+            />
+
+            <MarketSentimentCard />
+
+            <TerminalLogs />
+
+            <NeuralEngineCard />
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
     </SafeAreaView>
   );
 }

--- a/components/market-sentiment-card.tsx
+++ b/components/market-sentiment-card.tsx
@@ -1,0 +1,40 @@
+import { Ionicons } from "@expo/vector-icons";
+import { Text, View } from "react-native";
+
+import { tokens } from "@/constants/theme";
+
+type Level = "LOW" | "MEDIUM" | "HIGH";
+
+type Props = {
+  level?: Level;
+  saturation?: number;
+  description?: string;
+};
+
+export function MarketSentimentCard({
+  level = "HIGH",
+  saturation = 0.82,
+  description = "Current market conditions show extreme saturation in SaaS productivity tools. New entries require 10x differentiation.",
+}: Props) {
+  const pct = Math.max(0, Math.min(1, saturation)) * 100;
+
+  return (
+    <View className="rounded-sm border border-border bg-surface p-4">
+      <View className="mb-3 flex-row items-center justify-between">
+        <Text className="font-mono text-[12px] tracking-terminal text-ink">MARKET SENTIMENT</Text>
+        <Ionicons name="bar-chart" size={14} color={tokens.accent} />
+      </View>
+
+      <View className="mb-2 flex-row items-center justify-between">
+        <Text className="font-mono text-[10px] tracking-terminal text-ink-muted">SATURATION INDEX</Text>
+        <Text className="font-mono text-[11px] font-bold tracking-terminal text-accent">{level}</Text>
+      </View>
+
+      <View className="mb-3 h-1 w-full overflow-hidden rounded-full bg-elevated">
+        <View className="h-full rounded-full bg-accent" style={{ width: `${pct}%` }} />
+      </View>
+
+      <Text className="font-sans text-[12px] leading-[18px] text-ink-muted">{description}</Text>
+    </View>
+  );
+}

--- a/components/neural-engine-card.tsx
+++ b/components/neural-engine-card.tsx
@@ -1,0 +1,20 @@
+import { Ionicons } from "@expo/vector-icons";
+import { Text, View } from "react-native";
+
+import { tokens } from "@/constants/theme";
+
+export function NeuralEngineCard() {
+  return (
+    <View className="overflow-hidden rounded-sm border border-border bg-surface">
+      <View className="h-24 items-center justify-center bg-elevated">
+        <Ionicons name="hardware-chip-outline" size={40} color={tokens.inkDim} />
+      </View>
+      <View className="flex-row items-center gap-2 px-4 py-3">
+        <View className="h-2 w-2 rounded-full bg-status-pass" />
+        <Text className="font-mono text-[11px] tracking-terminal text-ink">
+          NEURAL ENGINE ACTIVE
+        </Text>
+      </View>
+    </View>
+  );
+}

--- a/components/primary-button.tsx
+++ b/components/primary-button.tsx
@@ -15,6 +15,9 @@ export function PrimaryButton({ label, icon = "flash", onPress, disabled }: Prop
     <Pressable
       onPress={onPress}
       disabled={disabled}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      accessibilityState={{ disabled: !!disabled }}
       className="w-full flex-row items-center justify-center gap-2 rounded-sm bg-accent px-4 py-4"
       style={({ pressed }) => ({ opacity: disabled ? 0.4 : pressed ? 0.85 : 1 })}
     >

--- a/components/primary-button.tsx
+++ b/components/primary-button.tsx
@@ -1,0 +1,25 @@
+import { Ionicons } from "@expo/vector-icons";
+import { Pressable, Text } from "react-native";
+
+import { tokens } from "@/constants/theme";
+
+type Props = {
+  label: string;
+  icon?: keyof typeof Ionicons.glyphMap;
+  onPress?: () => void;
+  disabled?: boolean;
+};
+
+export function PrimaryButton({ label, icon = "flash", onPress, disabled }: Props) {
+  return (
+    <Pressable
+      onPress={onPress}
+      disabled={disabled}
+      className="w-full flex-row items-center justify-center gap-2 rounded-sm bg-accent px-4 py-4"
+      style={({ pressed }) => ({ opacity: disabled ? 0.4 : pressed ? 0.85 : 1 })}
+    >
+      <Ionicons name={icon} size={16} color={tokens.bg} />
+      <Text className="font-mono text-[14px] font-bold tracking-terminal text-bg">{label}</Text>
+    </Pressable>
+  );
+}

--- a/components/section-card.tsx
+++ b/components/section-card.tsx
@@ -38,6 +38,8 @@ export function SectionCard({
         onChangeText={onChangeText}
         placeholder={placeholder}
         placeholderTextColor={tokens.inkDim}
+        accessibilityLabel={title}
+        accessibilityHint={placeholder}
         className="rounded-sm bg-elevated px-3 py-3 text-[13px] text-ink"
         style={{ minHeight, textAlignVertical: "top" }}
       />

--- a/components/section-card.tsx
+++ b/components/section-card.tsx
@@ -1,0 +1,46 @@
+import { Text, TextInput, View } from "react-native";
+
+import { tokens } from "@/constants/theme";
+
+type Props = {
+  number: string;
+  title: string;
+  required?: boolean;
+  placeholder?: string;
+  value: string;
+  onChangeText: (text: string) => void;
+  minHeight?: number;
+};
+
+export function SectionCard({
+  number,
+  title,
+  required,
+  placeholder,
+  value,
+  onChangeText,
+  minHeight = 96,
+}: Props) {
+  return (
+    <View className="rounded-sm border border-border bg-surface p-4">
+      <View className="mb-3 flex-row items-center justify-between">
+        <View className="flex-row items-center gap-3">
+          <Text className="font-mono text-[11px] tracking-terminal text-accent">{number}</Text>
+          <Text className="font-mono text-[12px] tracking-terminal text-ink">{title}</Text>
+        </View>
+        {required ? (
+          <Text className="font-mono text-[10px] tracking-terminal text-ink-dim">REQUIRED</Text>
+        ) : null}
+      </View>
+      <TextInput
+        multiline
+        value={value}
+        onChangeText={onChangeText}
+        placeholder={placeholder}
+        placeholderTextColor={tokens.inkDim}
+        className="rounded-sm bg-elevated px-3 py-3 text-[13px] text-ink"
+        style={{ minHeight, textAlignVertical: "top" }}
+      />
+    </View>
+  );
+}

--- a/components/terminal-logs.tsx
+++ b/components/terminal-logs.tsx
@@ -1,0 +1,37 @@
+import { Text, View } from "react-native";
+
+export type LogEntry = {
+  time: string;
+  message: string;
+  variant?: "info" | "error";
+};
+
+const DEFAULT_LOGS: LogEntry[] = [
+  { time: "08:24:15", message: "ANALYZING COMPETITOR LANDSCAPE..." },
+  { time: "08:24:14", message: "SCRAPING FUNDING DATA TRENDS..." },
+  { time: "08:24:13", message: "ERROR: IDEALISTIC PROJECTIONS DETECTED", variant: "error" },
+  { time: "08:24:12", message: "RE-CALIBRATING FOR MACRO-DOWNTURN..." },
+];
+
+export function TerminalLogs({ logs = DEFAULT_LOGS }: { logs?: LogEntry[] }) {
+  return (
+    <View className="rounded-sm border border-border bg-surface p-4">
+      <Text className="mb-3 font-mono text-[12px] tracking-terminal text-ink">
+        REAL-TIME VALIDATION LOGS
+      </Text>
+      <View className="gap-1">
+        {logs.map((log, i) => (
+          <Text
+            key={`${log.time}-${i}`}
+            numberOfLines={1}
+            className={`font-mono text-[10px] ${
+              log.variant === "error" ? "text-status-danger" : "text-ink-muted"
+            }`}
+          >
+            [{log.time}] {log.message}
+          </Text>
+        ))}
+      </View>
+    </View>
+  );
+}

--- a/components/terminal-logs.tsx
+++ b/components/terminal-logs.tsx
@@ -20,9 +20,9 @@ export function TerminalLogs({ logs = DEFAULT_LOGS }: { logs?: LogEntry[] }) {
         REAL-TIME VALIDATION LOGS
       </Text>
       <View className="gap-1">
-        {logs.map((log, i) => (
+        {logs.map((log) => (
           <Text
-            key={`${log.time}-${i}`}
+            key={`${log.time}-${log.message}`}
             numberOfLines={1}
             className={`font-mono text-[10px] ${
               log.variant === "error" ? "text-status-danger" : "text-ink-muted"


### PR DESCRIPTION
Closes #2

## Summary
Implements the validate/landing screen from `docs/figma/01-validate-landing.png`.

**New components (all with NativeWind + design tokens):**
- `PrimaryButton` — yellow CTA with bolt icon, disabled when form is incomplete
- `SectionCard` — numbered (`01`/`02`/…), `REQUIRED` tag, multiline `TextInput`
- `MarketSentimentCard` — saturation-index bar with `LOW`/`MEDIUM`/`HIGH` level
- `TerminalLogs` — terminal-style validation log feed (static for now; live in stage 6)
- `NeuralEngineCard` — `NEURAL ENGINE ACTIVE` indicator with chip icon

**Screen composition (`app/(tabs)/index.tsx`):**
- VALIDATION ENGINE V2.4 pill
- STRESS TEST YOUR IDEA display headline (yellow `YOUR`)
- Description copy
- Two `SectionCard`s: THE CONCEPT, FOUNDER BACKGROUND
- STRESS TEST THIS `PrimaryButton` (disabled until both inputs non-empty)
- Market Sentiment, Terminal Logs, Neural Engine cards
- Wrapped in `KeyboardAvoidingView` + `ScrollView`

Submit handler is a stub `Alert` until stage 6 wires the backend.

## Verification
- ✅ `npx tsc --noEmit` clean
- ✅ `npx expo export --platform web` succeeds (8.81 kB CSS, 2.25 MB JS bundle)
- ✅ Custom design tokens (`#F5C842` accent etc.) compile into the static CSS

## Test plan
- [ ] `npm run web` — landing page renders with the dark theme + yellow accents
- [ ] Both textareas accept input; CTA enables once both are non-empty
- [ ] `npm run ios` / `npm run android` — keyboard avoiding view works on both platforms
- [ ] Scroll behavior smooth; terminal logs and neural engine card visible at bottom