### PR TITLE
Stage 2: Synthesizing/loading screen with animated radar + pipeline

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
-import { Alert, KeyboardAvoidingView, Platform, ScrollView, Text, View } from "react-native";
+import { KeyboardAvoidingView, Platform, ScrollView, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import { AppHeader } from "@/components/app-header";
+import { LoadingView } from "@/components/loading-view";
 import { MarketSentimentCard } from "@/components/market-sentiment-card";
 import { NeuralEngineCard } from "@/components/neural-engine-card";
 import { PrimaryButton } from "@/components/primary-button";
@@ -12,80 +13,78 @@ import { TerminalLogs } from "@/components/terminal-logs";
 export default function ValidateScreen() {
   const [concept, setConcept] = useState("");
   const [background, setBackground] = useState("");
+  const [loading, setLoading] = useState(false);
 
   const canSubmit = concept.trim().length > 0 && background.trim().length > 0;
-
-  function onStressTest() {
-    Alert.alert(
-      "STRESS TEST INITIATED",
-      "Backend wiring lands in stage 6 — for now this only validates the form.",
-    );
-  }
 
   return (
     <SafeAreaView edges={["top"]} className="flex-1 bg-bg">
       <AppHeader />
-      <KeyboardAvoidingView
-        behavior={Platform.OS === "ios" ? "padding" : undefined}
-        className="flex-1"
-      >
-        <ScrollView
-          showsVerticalScrollIndicator={false}
-          keyboardShouldPersistTaps="handled"
-          contentContainerStyle={{ paddingBottom: 32 }}
+      {loading ? (
+        <LoadingView onCancel={() => setLoading(false)} />
+      ) : (
+        <KeyboardAvoidingView
+          behavior={Platform.OS === "ios" ? "padding" : undefined}
+          className="flex-1"
         >
-          <View className="gap-5 px-5 pt-6">
-            <View className="self-start rounded-sm bg-accent px-2 py-1">
-              <Text className="font-mono text-[11px] font-semibold tracking-terminal text-bg">
-                VALIDATION ENGINE V2.4
+          <ScrollView
+            showsVerticalScrollIndicator={false}
+            keyboardShouldPersistTaps="handled"
+            contentContainerStyle={{ paddingBottom: 32 }}
+          >
+            <View className="gap-5 px-5 pt-6">
+              <View className="self-start rounded-sm bg-accent px-2 py-1">
+                <Text className="font-mono text-[11px] font-semibold tracking-terminal text-bg">
+                  VALIDATION ENGINE V2.4
+                </Text>
+              </View>
+
+              <Text className="text-[56px] font-black leading-[1.0] text-ink">
+                STRESS{"\n"}TEST <Text className="text-accent">YOUR</Text>
+                {"\n"}IDEA
               </Text>
+
+              <Text className="font-sans text-[14px] leading-[20px] text-ink-muted">
+                Submit your concept to our ruthless, data-driven validation engine. We don&apos;t
+                do &quot;maybe.&quot; We do market reality.
+              </Text>
+
+              <SectionCard
+                number="01"
+                title="THE CONCEPT"
+                required
+                value={concept}
+                onChangeText={setConcept}
+                placeholder="Describe your project idea in detail. What problem does it solve? Who is the target user? How does it generate value?"
+                minHeight={110}
+              />
+
+              <SectionCard
+                number="02"
+                title="FOUNDER BACKGROUND"
+                required
+                value={background}
+                onChangeText={setBackground}
+                placeholder="Tell us why you are the right person to build this. Previous experience, unique insights, and available resources."
+                minHeight={110}
+              />
+
+              <PrimaryButton
+                label="STRESS TEST THIS"
+                icon="flash"
+                disabled={!canSubmit}
+                onPress={() => setLoading(true)}
+              />
+
+              <MarketSentimentCard />
+
+              <TerminalLogs />
+
+              <NeuralEngineCard />
             </View>
-
-            <Text className="text-[56px] font-black leading-[1.0] text-ink">
-              STRESS{"\n"}TEST <Text className="text-accent">YOUR</Text>
-              {"\n"}IDEA
-            </Text>
-
-            <Text className="font-sans text-[14px] leading-[20px] text-ink-muted">
-              Submit your concept to our ruthless, data-driven validation engine. We don&apos;t do
-              &quot;maybe.&quot; We do market reality.
-            </Text>
-
-            <SectionCard
-              number="01"
-              title="THE CONCEPT"
-              required
-              value={concept}
-              onChangeText={setConcept}
-              placeholder="Describe your project idea in detail. What problem does it solve? Who is the target user? How does it generate value?"
-              minHeight={110}
-            />
-
-            <SectionCard
-              number="02"
-              title="FOUNDER BACKGROUND"
-              required
-              value={background}
-              onChangeText={setBackground}
-              placeholder="Tell us why you are the right person to build this. Previous experience, unique insights, and available resources."
-              minHeight={110}
-            />
-
-            <PrimaryButton
-              label="STRESS TEST THIS"
-              icon="flash"
-              disabled={!canSubmit}
-              onPress={onStressTest}
-            />
-
-            <MarketSentimentCard />
-
-            <TerminalLogs />
-
-            <NeuralEngineCard />
-          </View>
-        </ScrollView>
-      </KeyboardAvoidingView>
+          </ScrollView>
+        </KeyboardAvoidingView>
+      )}
     </SafeAreaView>
   );
 }

--- a/components/diagnostic-pipeline.tsx
+++ b/components/diagnostic-pipeline.tsx
@@ -1,0 +1,133 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useEffect, useState } from "react";
+import { Text, View } from "react-native";
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withTiming,
+} from "react-native-reanimated";
+
+import { tokens } from "@/constants/theme";
+
+type Status = "pass" | "syncing" | "wait";
+
+const STEPS = [
+  "Consulting engineers...",
+  "Checking market...",
+  "Assessing feasibility...",
+  "Calculating ROI...",
+] as const;
+
+const FRAMES: Status[][] = [
+  ["syncing", "wait", "wait", "wait"],
+  ["pass", "syncing", "wait", "wait"],
+  ["pass", "pass", "syncing", "wait"],
+  ["pass", "pass", "pass", "syncing"],
+  ["pass", "pass", "pass", "pass"],
+];
+
+const FRAME_INTERVAL_MS = 1500;
+
+export function DiagnosticPipeline() {
+  const [frame, setFrame] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setFrame((f) => (f + 1) % FRAMES.length);
+    }, FRAME_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  const statuses = FRAMES[frame];
+
+  return (
+    <View className="rounded-sm border border-border bg-surface p-4">
+      <View className="mb-3 flex-row items-center justify-between border-b border-hairline pb-3">
+        <Text className="font-mono text-[12px] tracking-terminal text-ink">
+          DIAGNOSTIC PIPELINE
+        </Text>
+        <Text className="font-mono text-[10px] tracking-terminal text-ink-muted">
+          STATUS: <Text className="text-accent">ACTIVE</Text>
+        </Text>
+      </View>
+      <View className="gap-3">
+        {STEPS.map((label, i) => (
+          <PipelineRow key={label} label={label} status={statuses[i]} />
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function PipelineRow({ label, status }: { label: string; status: Status }) {
+  return (
+    <View className="flex-row items-center justify-between">
+      <View className="flex-row items-center gap-3">
+        <StatusIcon status={status} />
+        <Text
+          className={`font-sans text-[13px] ${status === "wait" ? "text-ink-dim" : "text-ink"}`}
+        >
+          {label}
+        </Text>
+      </View>
+      <StatusBadge status={status} />
+    </View>
+  );
+}
+
+function StatusIcon({ status }: { status: Status }) {
+  if (status === "pass") {
+    return <Ionicons name="checkmark-circle-outline" size={16} color={tokens.accent} />;
+  }
+  if (status === "syncing") {
+    return <SpinnerIcon />;
+  }
+  return <Ionicons name="ellipse-outline" size={16} color={tokens.inkDim} />;
+}
+
+function SpinnerIcon() {
+  const rotation = useSharedValue(0);
+
+  useEffect(() => {
+    rotation.value = withRepeat(
+      withTiming(360, { duration: 1000, easing: Easing.linear }),
+      -1,
+      false,
+    );
+  }, [rotation]);
+
+  const style = useAnimatedStyle(() => ({
+    transform: [{ rotate: `${rotation.value}deg` }],
+  }));
+
+  return (
+    <Animated.View style={style}>
+      <Ionicons name="sync-outline" size={16} color={tokens.inkMuted} />
+    </Animated.View>
+  );
+}
+
+const BADGE = {
+  pass: { label: "PASS", color: tokens.accent, border: tokens.accent },
+  syncing: { label: "SYNCING", color: tokens.inkMuted, border: tokens.inkMuted },
+  wait: { label: "WAIT", color: tokens.inkDim, border: tokens.inkDim },
+} as const;
+
+function StatusBadge({ status }: { status: Status }) {
+  const { label, color, border } = BADGE[status];
+  return (
+    <View
+      className="rounded-sm border px-2 py-0.5"
+      style={{ borderColor: border }}
+    >
+      <Text
+        className="font-mono text-[10px] font-bold tracking-terminal"
+        style={{ color }}
+      >
+        {label}
+      </Text>
+    </View>
+  );
+}

--- a/components/loading-view.tsx
+++ b/components/loading-view.tsx
@@ -15,13 +15,17 @@ export function LoadingView({ onCancel }: Props) {
     >
       <View className="gap-7 px-5 pt-8">
         <View className="items-center">
-          <Pressable
-            onPress={onCancel}
-            accessibilityRole="button"
-            accessibilityLabel="Cancel stress test"
-          >
+          {onCancel ? (
+            <Pressable
+              onPress={onCancel}
+              accessibilityRole="button"
+              accessibilityLabel="Cancel stress test"
+            >
+              <SynthesizingRadar size={240} />
+            </Pressable>
+          ) : (
             <SynthesizingRadar size={240} />
-          </Pressable>
+          )}
         </View>
 
         <View className="items-center">

--- a/components/loading-view.tsx
+++ b/components/loading-view.tsx
@@ -1,0 +1,55 @@
+import { Pressable, ScrollView, Text, View } from "react-native";
+
+import { DiagnosticPipeline } from "@/components/diagnostic-pipeline";
+import { SynthesizingRadar } from "@/components/synthesizing-radar";
+
+type Props = {
+  onCancel?: () => void;
+};
+
+export function LoadingView({ onCancel }: Props) {
+  return (
+    <ScrollView
+      contentContainerStyle={{ paddingBottom: 32 }}
+      showsVerticalScrollIndicator={false}
+    >
+      <View className="gap-7 px-5 pt-8">
+        <View className="items-center">
+          <Pressable
+            onPress={onCancel}
+            accessibilityRole="button"
+            accessibilityLabel="Cancel stress test"
+          >
+            <SynthesizingRadar size={240} />
+          </Pressable>
+        </View>
+
+        <View className="items-center">
+          <Text className="text-center text-4xl font-black leading-tight text-accent">
+            SYNTHESIZING{"\n"}VERDICT...
+          </Text>
+          <Text className="mt-3 font-mono text-[12px] tracking-terminal text-ink">
+            REALITY CHECK INCOMING.
+          </Text>
+        </View>
+
+        <DiagnosticPipeline />
+
+        <View className="flex-row items-start justify-between border-t border-hairline pt-4">
+          <FooterCell label="AUDIT_ID:" value="9X-2241" />
+          <FooterCell label="LATENCY:" value="14MS" />
+          <FooterCell label="SECURITY:" value="ENCRYPTED" />
+        </View>
+      </View>
+    </ScrollView>
+  );
+}
+
+function FooterCell({ label, value }: { label: string; value: string }) {
+  return (
+    <View>
+      <Text className="font-mono text-[9px] tracking-terminal text-ink-dim">{label}</Text>
+      <Text className="mt-1 font-mono text-[10px] tracking-terminal text-ink-muted">{value}</Text>
+    </View>
+  );
+}

--- a/components/synthesizing-radar.tsx
+++ b/components/synthesizing-radar.tsx
@@ -1,0 +1,113 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useEffect } from "react";
+import { View } from "react-native";
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withTiming,
+} from "react-native-reanimated";
+
+import { tokens } from "@/constants/theme";
+
+type Props = {
+  size?: number;
+};
+
+export function SynthesizingRadar({ size = 240 }: Props) {
+  const rotation = useSharedValue(0);
+
+  useEffect(() => {
+    rotation.value = withRepeat(
+      withTiming(360, { duration: 4000, easing: Easing.linear }),
+      -1,
+      false,
+    );
+  }, [rotation]);
+
+  const armStyle = useAnimatedStyle(() => ({
+    transform: [{ rotate: `${rotation.value}deg` }],
+  }));
+
+  const ring = (pct: number) => ({
+    position: "absolute" as const,
+    width: size * pct,
+    height: size * pct,
+    borderRadius: (size * pct) / 2,
+    borderWidth: 1,
+    borderColor: tokens.border,
+  });
+
+  return (
+    <View style={{ width: size, height: size }} className="items-center justify-center">
+      <View style={ring(1)} />
+      <View style={ring(0.66)} />
+      <View style={ring(0.33)} />
+
+      <View
+        style={{ position: "absolute", width: size, height: 1, backgroundColor: tokens.border }}
+      />
+      <View
+        style={{ position: "absolute", width: 1, height: size, backgroundColor: tokens.border }}
+      />
+
+      <View
+        style={{
+          position: "absolute",
+          top: size * 0.18,
+          left: size * 0.7,
+          width: 6,
+          height: 6,
+          borderRadius: 3,
+          backgroundColor: tokens.accent,
+        }}
+      />
+      <View
+        style={{
+          position: "absolute",
+          top: size * 0.55,
+          left: size * 0.32,
+          width: 4,
+          height: 4,
+          borderRadius: 2,
+          backgroundColor: tokens.accent,
+          opacity: 0.7,
+        }}
+      />
+
+      <Animated.View
+        pointerEvents="none"
+        style={[
+          {
+            position: "absolute",
+            width: size,
+            height: size,
+            alignItems: "center",
+            justifyContent: "center",
+          },
+          armStyle,
+        ]}
+      >
+        <View
+          style={{
+            position: "absolute",
+            top: size / 2 - 1,
+            left: size / 2,
+            width: size / 2,
+            height: 2,
+            backgroundColor: tokens.accent,
+            opacity: 0.7,
+          }}
+        />
+      </Animated.View>
+
+      <View
+        className="items-center justify-center rounded-full border border-accent"
+        style={{ width: 56, height: 56, backgroundColor: tokens.bg }}
+      >
+        <Ionicons name="analytics" size={20} color={tokens.accent} />
+      </View>
+    </View>
+  );
+}


### PR DESCRIPTION
Closes #3

## Summary
Implements the synthesizing/loading screen from `docs/figma/02-synthesizing-loading.png` as an alternate state of the Validate tab.

**New components:**
- `SynthesizingRadar` — concentric rings + crosshair grid + Reanimated 360° rotating sweep arm + center analytics icon + two stationary blip dots
- `DiagnosticPipeline` — 4-step pipeline with rotating Reanimated spinner for the active row and PASS/SYNCING/WAIT badge cycling through 5 frames at 1500ms intervals
- `LoadingView` — full loading composition (radar + SYNTHESIZING VERDICT headline + REALITY CHECK INCOMING subtitle + pipeline + AUDIT_ID/LATENCY/SECURITY footer)

**Wiring:**
- Validate tab tracks a `loading` boolean. STRESS TEST THIS now flips it to `true`. Tapping the radar cancels back to the form.
- Stage 6 will replace the cancel-on-tap with the real navigation to the report screen on completion.

**Note:** the Figma mockup says `SYTHESIZING` (missing N) — implementation uses the correct spelling `SYNTHESIZING`.

## Verification
- ✅ `npx tsc --noEmit` clean
- ✅ `npx expo export --platform web` succeeds
- ✅ Reanimated worklets (rotation) compile cleanly under the babel preset

## Test plan
- [ ] `npm run web` — fill both inputs, tap STRESS TEST THIS → loading view shows with rotating radar arm + spinning SYNCING icon
- [ ] Pipeline cycles through Consulting → Checking → Assessing → Calculating, badges advance every ~1.5s
- [ ] Tap radar cancels back to the form
- [ ] `npm run ios` / `npm run android` — animations run at 60fps