### PR TITLE
Stage 3: Builder + Investor report screens

### DIFF
--- a/app/(tabs)/reports.tsx
+++ b/app/(tabs)/reports.tsx
@@ -1,17 +1,244 @@
-import { Text, View } from "react-native";
+import { useState } from "react";
+import { ScrollView, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import { AppHeader } from "@/components/app-header";
+import { CollapsibleSection } from "@/components/collapsible-section";
+import { CriticalConcerns, type Concern } from "@/components/critical-concerns";
+import { FinalRecommendationBar } from "@/components/final-recommendation-bar";
+import { MarketSizeBars } from "@/components/market-size-bars";
+import { type MetricCardProps } from "@/components/metric-card";
+import { MetricsGrid } from "@/components/metrics-grid";
+import { ScoreDisplay } from "@/components/score-display";
+import { StrengthsVulnerabilities } from "@/components/strengths-vulnerabilities";
+import { ViewToggle, type ReportView } from "@/components/view-toggle";
+
+const REPORT = {
+  title: "ORBITAL SYNC",
+  description:
+    "High-precision cloud orchestration engine for distributed aerospace telemetry systems. Validated against current market latency and scalability benchmarks.",
+};
+
+const BUILDER_METRICS: MetricCardProps[] = [
+  { label: "OVERALL SCORE", value: "6.8", unit: "/10", progress: 0.68 },
+  { label: "EST. EFFORT", value: "HIGH", subtitle: "~1,200 Engineering Hrs" },
+  {
+    label: "RISK LEVEL",
+    value: "ELEVATED",
+    valueColor: "danger",
+    subtitle: "Data Consistency Hazard",
+  },
+  { label: "MVP TIMELINE", value: "6-8 WKS", subtitle: "To Alpha release" },
+];
+
+const INVESTOR_METRICS: MetricCardProps[] = [
+  {
+    label: "INVESTABILITY SCORE",
+    value: "6.5",
+    unit: "/10",
+    progress: 0.65,
+    icon: "trending-up",
+  },
+  {
+    label: "MARKET SIZE (TAM)",
+    value: "$12B",
+    subtitle: "Global Logistics Segment",
+    icon: "pie-chart-outline",
+  },
+  {
+    label: "DEFENSIBILITY",
+    value: "LOW",
+    valueColor: "danger",
+    subtitle: "Open Source Threats",
+    icon: "shield-outline",
+  },
+  {
+    label: "TRACTION GOAL",
+    value: "10 Pilots",
+    subtitle: "Q4 2024 Milestone",
+    icon: "locate-outline",
+  },
+];
+
+const CONCERNS: Concern[] = [
+  {
+    title: "LOW BARRIER TO ENTRY",
+    description:
+      "Multiple open-source alternatives are emerging in the orbital tracking space, potentially commoditizing the primary feature set.",
+  },
+  {
+    title: "REGULATORY RISK",
+    description:
+      "New space traffic management protocols pending in the EU could require massive architectural changes within 12 months.",
+  },
+  {
+    title: "SALES CYCLE",
+    description:
+      "Initial pilot feedback suggests 18-month sales cycles for Tier 1 satellite operators, exceeding current runway projections.",
+  },
+];
 
 export default function ReportsScreen() {
+  const [view, setView] = useState<ReportView>("builder");
+
   return (
     <SafeAreaView edges={["top"]} className="flex-1 bg-bg">
       <AppHeader />
-      <View className="flex-1 items-center justify-center px-6">
-        <Text className="font-mono text-[11px] tracking-terminal text-ink-muted">
-          NO REPORTS YET
-        </Text>
+      <View className="flex-1">
+        <ScrollView
+          showsVerticalScrollIndicator={false}
+          contentContainerStyle={{ paddingBottom: view === "builder" ? 120 : 32 }}
+        >
+          <View className="gap-5 px-5 pt-6">
+            <View>
+              <Text className="font-mono text-[10px] tracking-terminal text-ink-muted">
+                ANALYSIS REPORT
+              </Text>
+              <Text className="mt-1 font-mono text-[14px] font-bold tracking-terminal text-ink">
+                {REPORT.title}
+              </Text>
+              <Text className="mt-3 font-sans text-[13px] leading-[18px] text-ink-muted">
+                {REPORT.description}
+              </Text>
+            </View>
+
+            <ViewToggle value={view} onChange={setView} />
+
+            {view === "builder" ? <BuilderView /> : <InvestorView />}
+          </View>
+        </ScrollView>
+
+        {view === "builder" ? (
+          <FinalRecommendationBar
+            primaryLabel="INITIATE_BUILD"
+            secondaryLabel="PROCEED WITH REDUCED SCOPE"
+          />
+        ) : null}
       </View>
     </SafeAreaView>
+  );
+}
+
+function BuilderView() {
+  return (
+    <>
+      <MetricsGrid metrics={BUILDER_METRICS} layout="grid" />
+
+      <CollapsibleSection number="01" title="PROBLEM CLARITY" defaultOpen>
+        <View className="gap-4">
+          <Text className="font-sans text-[13px] leading-[18px] text-ink-muted">
+            The core problem addresses the massive sync latency between ground-station data
+            processing and cloud-based telemetry storage. Current solutions lag by &gt;500ms,
+            whereas Orbital Sync proposes a sub-50ms window using Edge-Native pre-processing.
+          </Text>
+
+          <StrengthsVulnerabilities
+            strengths={[
+              "Identifiable high-value bottleneck.",
+              "Clear differentiation from incumbents.",
+            ]}
+            vulnerabilities={[
+              "High dependency on hardware API access.",
+              "Narrow target market (Enterprise focus).",
+            ]}
+          />
+
+          <ScoreDisplay label="Clarity Score" value="8.5" />
+        </View>
+      </CollapsibleSection>
+
+      <CollapsibleSection number="02" title="TECHNICAL FEASIBILITY">
+        <Text className="font-sans text-[13px] leading-[18px] text-ink-muted">
+          Edge pre-processing architecture is feasible with existing hardware vendor APIs but
+          requires deep firmware-level optimization.
+        </Text>
+      </CollapsibleSection>
+
+      <CollapsibleSection number="03" title="LEARNING VALUE">
+        <Text className="font-sans text-[13px] leading-[18px] text-ink-muted">
+          High exposure to distributed systems, satellite telemetry pipelines, and edge compute
+          orchestration.
+        </Text>
+      </CollapsibleSection>
+
+      <CollapsibleSection number="04" title="APPROACHES TO BUILD">
+        <Text className="font-sans text-[13px] leading-[18px] text-ink-muted">
+          Three viable paths: (1) Lean MVP with sandbox simulator, (2) pilot integration with
+          one Tier-2 partner, (3) full vertical-stack research prototype.
+        </Text>
+      </CollapsibleSection>
+    </>
+  );
+}
+
+function InvestorView() {
+  return (
+    <>
+      <MetricsGrid metrics={INVESTOR_METRICS} layout="stack" />
+
+      <CollapsibleSection
+        number="1."
+        title="MARKET SIZE ASSESSMENT"
+        icon="bar-chart-outline"
+        defaultOpen
+      >
+        <View className="gap-4">
+          <MarketSizeBars
+            bars={[
+              {
+                label: "TAM (TOTAL ADDRESSABLE MARKET)",
+                value: "$12,000,000,000",
+                width: 1.0,
+              },
+              {
+                label: "SAM (SERVICEABLE ADDRESSABLE MARKET)",
+                value: "$4,200,000,000",
+                width: 0.35,
+              },
+              {
+                label: "SOM (SERVICEABLE OBTAINABLE MARKET)",
+                value: "$850,000,000",
+                width: 0.07,
+              },
+            ]}
+          />
+
+          <View className="items-center rounded-sm bg-elevated px-4 py-7">
+            <Text className="font-mono text-[10px] tracking-terminal text-ink-dim">
+              TARGET SECTOR
+            </Text>
+            <Text className="mt-2 font-mono text-[20px] font-black tracking-terminal text-accent">
+              ORBITAL LOGISTICS
+            </Text>
+          </View>
+        </View>
+      </CollapsibleSection>
+
+      <CollapsibleSection number="2." title="DEFENSIBILITY MOATS" icon="shield-outline">
+        <Text className="font-sans text-[13px] leading-[18px] text-ink-muted">
+          Initial moat is technical-differentiation only; patentability of edge sync algorithms
+          is contested.
+        </Text>
+      </CollapsibleSection>
+
+      <CollapsibleSection
+        number="3."
+        title="TRACTION REQUIREMENTS"
+        icon="trending-up-outline"
+      >
+        <Text className="font-sans text-[13px] leading-[18px] text-ink-muted">
+          10 paid pilots within 12 months at $80k–$120k ACV to reach Series-A readiness.
+        </Text>
+      </CollapsibleSection>
+
+      <CollapsibleSection number="4." title="BUSINESS MODEL" icon="business-outline">
+        <Text className="font-sans text-[13px] leading-[18px] text-ink-muted">
+          Tiered usage-based pricing with premium SLAs for Tier-1 operators; long-term licensing
+          as upsell.
+        </Text>
+      </CollapsibleSection>
+
+      <CriticalConcerns concerns={CONCERNS} />
+    </>
   );
 }

--- a/app/(tabs)/reports.tsx
+++ b/app/(tabs)/reports.tsx
@@ -80,14 +80,18 @@ const CONCERNS: Concern[] = [
 
 export default function ReportsScreen() {
   const [view, setView] = useState<ReportView>("builder");
+  const [footerHeight, setFooterHeight] = useState(0);
 
   return (
     <SafeAreaView edges={["top"]} className="flex-1 bg-bg">
       <AppHeader />
       <View className="flex-1">
         <ScrollView
+          className="flex-1"
           showsVerticalScrollIndicator={false}
-          contentContainerStyle={{ paddingBottom: view === "builder" ? 120 : 32 }}
+          contentContainerStyle={{
+            paddingBottom: (view === "builder" ? footerHeight : 0) + 32,
+          }}
         >
           <View className="gap-5 px-5 pt-6">
             <View>
@@ -109,10 +113,15 @@ export default function ReportsScreen() {
         </ScrollView>
 
         {view === "builder" ? (
-          <FinalRecommendationBar
-            primaryLabel="INITIATE_BUILD"
-            secondaryLabel="PROCEED WITH REDUCED SCOPE"
-          />
+          <View
+            onLayout={(e) => setFooterHeight(e.nativeEvent.layout.height)}
+            className="absolute bottom-0 left-0 right-0"
+          >
+            <FinalRecommendationBar
+              primaryLabel="INITIATE_BUILD"
+              secondaryLabel="PROCEED WITH REDUCED SCOPE"
+            />
+          </View>
         ) : null}
       </View>
     </SafeAreaView>

--- a/components/collapsible-section.tsx
+++ b/components/collapsible-section.tsx
@@ -1,0 +1,51 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useState, type ReactNode } from "react";
+import { Pressable, Text, View } from "react-native";
+
+import { tokens } from "@/constants/theme";
+
+type Props = {
+  number: string;
+  title: string;
+  defaultOpen?: boolean;
+  icon?: keyof typeof Ionicons.glyphMap;
+  children?: ReactNode;
+};
+
+export function CollapsibleSection({
+  number,
+  title,
+  defaultOpen = false,
+  icon,
+  children,
+}: Props) {
+  const [open, setOpen] = useState(defaultOpen);
+
+  return (
+    <View
+      className={`rounded-sm border bg-surface ${open ? "border-accent" : "border-border"}`}
+    >
+      <Pressable
+        accessibilityRole="button"
+        accessibilityState={{ expanded: open }}
+        accessibilityLabel={`${title}, section ${number}`}
+        onPress={() => setOpen((v) => !v)}
+        className="flex-row items-center justify-between px-4 py-3"
+      >
+        <View className="flex-row items-center gap-3">
+          {icon ? <Ionicons name={icon} size={14} color={tokens.inkMuted} /> : null}
+          <Text className="font-mono text-[11px] tracking-terminal text-accent">{number}</Text>
+          <Text className="font-mono text-[12px] tracking-terminal text-ink">{title}</Text>
+        </View>
+        <Ionicons
+          name={open ? "chevron-up" : "chevron-down"}
+          size={16}
+          color={tokens.inkMuted}
+        />
+      </Pressable>
+      {open && children ? (
+        <View className="border-t border-hairline px-4 pb-4 pt-4">{children}</View>
+      ) : null}
+    </View>
+  );
+}

--- a/components/critical-concerns.tsx
+++ b/components/critical-concerns.tsx
@@ -1,0 +1,37 @@
+import { Ionicons } from "@expo/vector-icons";
+import { Text, View } from "react-native";
+
+import { tokens } from "@/constants/theme";
+
+export type Concern = {
+  title: string;
+  description: string;
+};
+
+export function CriticalConcerns({ concerns }: { concerns: Concern[] }) {
+  return (
+    <View className="gap-3">
+      <View className="flex-row items-center gap-2">
+        <Ionicons name="warning-outline" size={14} color={tokens.accent} />
+        <Text className="font-mono text-[12px] tracking-terminal text-ink">
+          CRITICAL CONCERNS
+        </Text>
+      </View>
+      <View className="gap-2">
+        {concerns.map((c) => (
+          <View key={c.title} className="rounded-sm border border-border bg-surface p-3">
+            <View className="mb-2 flex-row items-center gap-2">
+              <Ionicons name="alert-circle-outline" size={13} color={tokens.accent} />
+              <Text className="font-mono text-[10px] tracking-terminal text-accent">
+                {c.title}
+              </Text>
+            </View>
+            <Text className="font-sans text-[12px] leading-[16px] text-ink-muted">
+              {c.description}
+            </Text>
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}

--- a/components/final-recommendation-bar.tsx
+++ b/components/final-recommendation-bar.tsx
@@ -1,0 +1,44 @@
+import { Text, View } from "react-native";
+
+import { PrimaryButton } from "@/components/primary-button";
+
+type Props = {
+  primaryLabel: string;
+  secondaryLabel?: string;
+  onPrimary?: () => void;
+  onSecondary?: () => void;
+};
+
+export function FinalRecommendationBar({
+  primaryLabel,
+  secondaryLabel,
+  onPrimary,
+  onSecondary,
+}: Props) {
+  return (
+    <View className="border-t border-border bg-bg px-4 py-3">
+      <Text className="mb-2 font-mono text-[9px] tracking-terminal text-ink-dim">
+        FINAL RECOMMENDATION
+      </Text>
+      <View className="flex-row gap-2">
+        {secondaryLabel ? (
+          <View className="flex-1">
+            <PrimaryButton
+              label={secondaryLabel}
+              variant="outline"
+              onPress={onSecondary}
+            />
+          </View>
+        ) : null}
+        <View className="flex-1">
+          <PrimaryButton
+            label={primaryLabel}
+            variant="solid"
+            icon="rocket"
+            onPress={onPrimary}
+          />
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/components/final-recommendation-bar.tsx
+++ b/components/final-recommendation-bar.tsx
@@ -27,6 +27,7 @@ export function FinalRecommendationBar({
               label={secondaryLabel}
               variant="outline"
               onPress={onSecondary}
+              disabled={!onSecondary}
             />
           </View>
         ) : null}
@@ -36,6 +37,7 @@ export function FinalRecommendationBar({
             variant="solid"
             icon="rocket"
             onPress={onPrimary}
+            disabled={!onPrimary}
           />
         </View>
       </View>

--- a/components/market-size-bars.tsx
+++ b/components/market-size-bars.tsx
@@ -1,0 +1,35 @@
+import { Text, View } from "react-native";
+
+export type MarketBar = {
+  label: string;
+  value: string;
+  width: number;
+};
+
+export function MarketSizeBars({ bars }: { bars: MarketBar[] }) {
+  return (
+    <View className="gap-3">
+      {bars.map((bar) => (
+        <View key={bar.label}>
+          <View className="mb-1 flex-row items-center justify-between">
+            <Text
+              className="flex-1 font-mono text-[9px] tracking-terminal text-ink-muted"
+              numberOfLines={1}
+            >
+              {bar.label}
+            </Text>
+            <Text className="ml-2 font-mono text-[11px] tracking-terminal text-ink">
+              {bar.value}
+            </Text>
+          </View>
+          <View className="h-2 w-full overflow-hidden rounded-sm bg-elevated">
+            <View
+              className="h-full bg-accent"
+              style={{ width: `${Math.max(0, Math.min(1, bar.width)) * 100}%` }}
+            />
+          </View>
+        </View>
+      ))}
+    </View>
+  );
+}

--- a/components/metric-card.tsx
+++ b/components/metric-card.tsx
@@ -1,0 +1,62 @@
+import { Ionicons } from "@expo/vector-icons";
+import { Text, View } from "react-native";
+
+import { tokens } from "@/constants/theme";
+
+export type MetricCardProps = {
+  label: string;
+  value: string;
+  unit?: string;
+  subtitle?: string;
+  valueColor?: "accent" | "danger" | "ink";
+  progress?: number;
+  icon?: keyof typeof Ionicons.glyphMap;
+};
+
+export function MetricCard({
+  label,
+  value,
+  unit,
+  subtitle,
+  valueColor = "accent",
+  progress,
+  icon,
+}: MetricCardProps) {
+  const colorClass =
+    valueColor === "danger"
+      ? "text-status-danger"
+      : valueColor === "ink"
+        ? "text-ink"
+        : "text-accent";
+
+  return (
+    <View className="flex-1 rounded-sm border border-border bg-surface p-4">
+      <View className="mb-2 flex-row items-center justify-between">
+        <Text className="font-mono text-[10px] tracking-terminal text-ink-muted" numberOfLines={1}>
+          {label}
+        </Text>
+        {icon ? <Ionicons name={icon} size={14} color={tokens.accent} /> : null}
+      </View>
+      <View className="flex-row items-baseline gap-1">
+        <Text className={`text-[26px] font-black ${colorClass}`}>{value}</Text>
+        {unit ? <Text className="font-mono text-[12px] text-ink-dim">{unit}</Text> : null}
+      </View>
+      {progress !== undefined ? (
+        <View className="mt-2 h-1 w-full overflow-hidden rounded-full bg-elevated">
+          <View
+            className="h-full rounded-full bg-accent"
+            style={{ width: `${Math.max(0, Math.min(1, progress)) * 100}%` }}
+          />
+        </View>
+      ) : null}
+      {subtitle ? (
+        <Text
+          className="mt-2 font-mono text-[10px] tracking-terminal text-ink-dim"
+          numberOfLines={2}
+        >
+          {subtitle}
+        </Text>
+      ) : null}
+    </View>
+  );
+}

--- a/components/metrics-grid.tsx
+++ b/components/metrics-grid.tsx
@@ -1,0 +1,42 @@
+import { View } from "react-native";
+
+import { MetricCard, type MetricCardProps } from "@/components/metric-card";
+
+type Layout = "grid" | "stack";
+
+type Props = {
+  metrics: MetricCardProps[];
+  layout?: Layout;
+};
+
+export function MetricsGrid({ metrics, layout = "grid" }: Props) {
+  if (metrics.length === 0) return null;
+
+  if (layout === "stack") {
+    return (
+      <View className="gap-2">
+        {metrics.map((m) => (
+          <MetricCard key={m.label} {...m} />
+        ))}
+      </View>
+    );
+  }
+
+  const rows: MetricCardProps[][] = [];
+  for (let i = 0; i < metrics.length; i += 2) {
+    rows.push(metrics.slice(i, i + 2));
+  }
+
+  return (
+    <View className="gap-2">
+      {rows.map((row) => (
+        <View key={row.map((r) => r.label).join("|")} className="flex-row gap-2">
+          {row.map((m) => (
+            <MetricCard key={m.label} {...m} />
+          ))}
+          {row.length < 2 ? <View className="flex-1" /> : null}
+        </View>
+      ))}
+    </View>
+  );
+}

--- a/components/primary-button.tsx
+++ b/components/primary-button.tsx
@@ -3,14 +3,20 @@ import { Pressable, Text } from "react-native";
 
 import { tokens } from "@/constants/theme";
 
+type Variant = "solid" | "outline";
+
 type Props = {
   label: string;
   icon?: keyof typeof Ionicons.glyphMap;
   onPress?: () => void;
   disabled?: boolean;
+  variant?: Variant;
 };
 
-export function PrimaryButton({ label, icon = "flash", onPress, disabled }: Props) {
+export function PrimaryButton({ label, icon, onPress, disabled, variant = "solid" }: Props) {
+  const solid = variant === "solid";
+  const fg = solid ? tokens.bg : tokens.accent;
+
   return (
     <Pressable
       onPress={onPress}
@@ -18,11 +24,18 @@ export function PrimaryButton({ label, icon = "flash", onPress, disabled }: Prop
       accessibilityRole="button"
       accessibilityLabel={label}
       accessibilityState={{ disabled: !!disabled }}
-      className="w-full flex-row items-center justify-center gap-2 rounded-sm bg-accent px-4 py-4"
+      className={`w-full flex-row items-center justify-center gap-2 rounded-sm px-4 py-4 ${
+        solid ? "bg-accent" : "border border-accent"
+      }`}
       style={({ pressed }) => ({ opacity: disabled ? 0.4 : pressed ? 0.85 : 1 })}
     >
-      <Ionicons name={icon} size={16} color={tokens.bg} />
-      <Text className="font-mono text-[14px] font-bold tracking-terminal text-bg">{label}</Text>
+      {icon ? <Ionicons name={icon} size={16} color={fg} /> : null}
+      <Text
+        className="font-mono text-[13px] font-bold tracking-terminal"
+        style={{ color: fg }}
+      >
+        {label}
+      </Text>
     </Pressable>
   );
 }

--- a/components/score-display.tsx
+++ b/components/score-display.tsx
@@ -1,0 +1,15 @@
+import { Text, View } from "react-native";
+
+type Props = {
+  label: string;
+  value: string;
+};
+
+export function ScoreDisplay({ label, value }: Props) {
+  return (
+    <View className="items-center rounded-sm bg-elevated px-4 py-5">
+      <Text className="mb-1 font-mono text-[10px] tracking-terminal text-accent">{label}</Text>
+      <Text className="text-[36px] font-black text-ink">{value}</Text>
+    </View>
+  );
+}

--- a/components/strengths-vulnerabilities.tsx
+++ b/components/strengths-vulnerabilities.tsx
@@ -1,0 +1,56 @@
+import { Ionicons } from "@expo/vector-icons";
+import { Text, View } from "react-native";
+
+import { tokens } from "@/constants/theme";
+
+type Props = {
+  strengths: string[];
+  vulnerabilities: string[];
+};
+
+export function StrengthsVulnerabilities({ strengths, vulnerabilities }: Props) {
+  return (
+    <View className="flex-row gap-3">
+      <Column
+        title="STRENGTHS"
+        items={strengths}
+        icon="checkmark-circle"
+        color={tokens.accent}
+      />
+      <Column
+        title="VULNERABILITIES"
+        items={vulnerabilities}
+        icon="warning"
+        color={tokens.danger}
+      />
+    </View>
+  );
+}
+
+function Column({
+  title,
+  items,
+  icon,
+  color,
+}: {
+  title: string;
+  items: string[];
+  icon: keyof typeof Ionicons.glyphMap;
+  color: string;
+}) {
+  return (
+    <View className="flex-1 gap-2">
+      <Text className="font-mono text-[10px] tracking-terminal" style={{ color }}>
+        {title}
+      </Text>
+      {items.map((item) => (
+        <View key={item} className="flex-row items-start gap-2">
+          <Ionicons name={icon} size={12} color={color} style={{ marginTop: 2 }} />
+          <Text className="flex-1 font-sans text-[12px] leading-[16px] text-ink-muted">
+            {item}
+          </Text>
+        </View>
+      ))}
+    </View>
+  );
+}

--- a/components/view-toggle.tsx
+++ b/components/view-toggle.tsx
@@ -9,7 +9,10 @@ type Props = {
 
 export function ViewToggle({ value, onChange }: Props) {
   return (
-    <View className="flex-row rounded-sm border border-border bg-surface p-1">
+    <View
+      accessibilityRole="tablist"
+      className="flex-row rounded-sm border border-border bg-surface p-1"
+    >
       <Toggle
         label="BUILDER"
         active={value === "builder"}

--- a/components/view-toggle.tsx
+++ b/components/view-toggle.tsx
@@ -1,0 +1,53 @@
+import { Pressable, Text, View } from "react-native";
+
+export type ReportView = "builder" | "investor";
+
+type Props = {
+  value: ReportView;
+  onChange: (v: ReportView) => void;
+};
+
+export function ViewToggle({ value, onChange }: Props) {
+  return (
+    <View className="flex-row rounded-sm border border-border bg-surface p-1">
+      <Toggle
+        label="BUILDER"
+        active={value === "builder"}
+        onPress={() => onChange("builder")}
+      />
+      <Toggle
+        label="INVESTOR"
+        active={value === "investor"}
+        onPress={() => onChange("investor")}
+      />
+    </View>
+  );
+}
+
+function Toggle({
+  label,
+  active,
+  onPress,
+}: {
+  label: string;
+  active: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="tab"
+      accessibilityState={{ selected: active }}
+      accessibilityLabel={label}
+      className={`flex-1 items-center justify-center rounded-sm py-2 ${active ? "bg-accent" : ""}`}
+    >
+      <Text
+        className={`font-mono text-[11px] font-bold tracking-terminal ${
+          active ? "text-bg" : "text-ink-muted"
+        }`}
+      >
+        {label}
+      </Text>
+    </Pressable>
+  );
+}


### PR DESCRIPTION
Closes #4

## Summary
Implements the report screens from `docs/figma/03-builder-report.png` and `docs/figma/04-investor-report.png` as the Reports tab.

**New components:**
- `MetricCard` / `MetricsGrid` — `grid` (2x2) layout for builder, `stack` for investor; investor cards include top-right icons
- `CollapsibleSection` — numbered title + chevron toggle, optional left icon (used for investor sections); first section in each view defaults to open with the gold-border treatment
- `StrengthsVulnerabilities` — two-column ✓/⚠ list (Problem Clarity)
- `ScoreDisplay` — large centered score (Clarity Score 8.5)
- `MarketSizeBars` — TAM/SAM/SOM horizontal bars
- `CriticalConcerns` — alert-style list (Investor view only)
- `ViewToggle` — pill toggle to switch BUILDER / INVESTOR
- `FinalRecommendationBar` — sticky bottom with two CTAs (`PROCEED WITH REDUCED SCOPE` outline / `INITIATE_BUILD` solid); shown for builder view only

**PrimaryButton** got an `outline` variant for the secondary CTA.

**Wiring:** Reports tab now renders the full ORBITAL SYNC mock report. Data is hardcoded in the screen for now and will come from Supabase in stage 6.

## Verification
- ✅ `npx tsc --noEmit` clean
- ✅ `npx expo export --platform web` succeeds (`/reports` static page = 32.9 kB)

## Test plan
- [ ] `npm run web` — Reports tab shows ORBITAL SYNC builder view by default
- [ ] BUILDER toggle: 2x2 metrics, Problem Clarity expanded with strengths/vulnerabilities + Clarity Score 8.5
- [ ] Tap each section header → expands/collapses with chevron flip
- [ ] INVESTOR toggle: stacked metric cards with icons, Market Size Assessment expanded with TAM/SAM/SOM bars + ORBITAL LOGISTICS callout, Critical Concerns visible at the bottom
- [ ] FINAL RECOMMENDATION sticky footer is only visible on Builder view
- [ ] `npm run ios` / `npm run android` — scrolling smooth, sticky footer pinned