### PR TITLE
Stage 6: wire app to analyze flow

### DIFF
--- a/app.json
+++ b/app.json
@@ -45,6 +45,11 @@
     "experiments": {
       "typedRoutes": true,
       "reactCompiler": true
+    },
+    "extra": {
+      "supabaseUrl": "https://hexcsdactbhdkcmdrnzj.supabase.co",
+      "supabaseAnonKey": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImhleGNzZGFjdGJoZGtjbWRybnpqIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Nzc4MTAzMzcsImV4cCI6MjA5MzM4NjMzN30.0983qPQ-aKankekobLuDG3o5SGEJZdXBkzkOrSOduP0",
+      "publicReportBaseUrl": "https://should-i-build-this.vercel.app"
     }
   }
 }

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,4 +1,6 @@
-import { useState } from "react";
+import { Ionicons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
+import { useEffect, useRef, useState } from "react";
 import {
   KeyboardAvoidingView,
   Platform,
@@ -14,28 +16,71 @@ import { AppHeader } from "@/components/app-header";
 import { LoadingView } from "@/components/loading-view";
 import { MarketSentimentCard } from "@/components/market-sentiment-card";
 import { NeuralEngineCard } from "@/components/neural-engine-card";
+import { useReportSession } from "@/components/report-session-provider";
 import { SectionCard } from "@/components/section-card";
 import { TerminalLogs } from "@/components/terminal-logs";
 import { tokens } from "@/constants/theme";
-import { Ionicons } from "@expo/vector-icons";
+import { invokeAnalyze } from "@/lib/analyze-client";
 
 export default function ValidateScreen() {
+  const router = useRouter();
+  const { clearSession, setSession } = useReportSession();
   const [concept, setConcept] = useState("");
   const [background, setBackground] = useState("");
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
 
   const canSubmit = concept.trim().length > 0 && background.trim().length > 0;
 
-  const handleStressTestPress = () => {
+  useEffect(() => {
+    return () => abortRef.current?.abort();
+  }, []);
+
+  const handleStressTestPress = async () => {
     if (!canSubmit) return;
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+    clearSession();
+    setError(null);
     setLoading(true);
+
+    try {
+      const response = await invokeAnalyze(
+        {
+          ideaText: concept.trim(),
+          backgroundText: background.trim(),
+        },
+        controller.signal,
+      );
+
+      setSession(response);
+      setLoading(false);
+      router.push("/reports");
+    } catch (requestError) {
+      if ((requestError as Error).name === "AbortError") {
+        return;
+      }
+
+      setLoading(false);
+      setError((requestError as Error).message || "Stress test failed. Try again.");
+    } finally {
+      abortRef.current = null;
+    }
+  };
+
+  const handleCancel = () => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setLoading(false);
   };
 
   return (
     <SafeAreaView edges={["top"]} style={styles.safeArea}>
       <AppHeader />
       {loading ? (
-        <LoadingView onCancel={() => setLoading(false)} />
+        <LoadingView onCancel={handleCancel} />
       ) : (
         <KeyboardAvoidingView
           behavior={Platform.OS === "ios" ? "padding" : undefined}
@@ -94,8 +139,8 @@ export default function ValidateScreen() {
                   <View
                     style={[
                       styles.ctaButton,
-                      !canSubmit ? styles.ctaButtonDisabled : null,
                       pressed ? styles.ctaButtonPressed : null,
+                      !canSubmit ? styles.ctaButtonDisabled : null,
                     ]}
                   >
                     <Ionicons name="flash" size={16} color={tokens.bg} />
@@ -103,6 +148,8 @@ export default function ValidateScreen() {
                   </View>
                 )}
               </Pressable>
+
+              {error ? <Text style={styles.errorText}>{error}</Text> : null}
 
               <MarketSentimentCard />
 
@@ -189,5 +236,11 @@ const styles = StyleSheet.create({
     fontFamily: "Inter_700Bold",
     fontSize: 12,
     letterSpacing: 0.8,
+  },
+  errorText: {
+    color: "#fca5a5",
+    fontFamily: "Inter_400Regular",
+    fontSize: 12,
+    lineHeight: 18,
   },
 });

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -24,7 +24,7 @@ import { invokeAnalyze } from "@/lib/analyze-client";
 
 export default function ValidateScreen() {
   const router = useRouter();
-  const { clearSession, setSession } = useReportSession();
+  const { setSession } = useReportSession();
   const [concept, setConcept] = useState("");
   const [background, setBackground] = useState("");
   const [loading, setLoading] = useState(false);
@@ -42,7 +42,6 @@ export default function ValidateScreen() {
 
     const controller = new AbortController();
     abortRef.current = controller;
-    clearSession();
     setError(null);
     setLoading(true);
 

--- a/app/(tabs)/reports.tsx
+++ b/app/(tabs)/reports.tsx
@@ -1,6 +1,8 @@
+import { Ionicons } from "@expo/vector-icons";
+import * as Clipboard from "expo-clipboard";
 import { LinearGradient } from "expo-linear-gradient";
 import { useState } from "react";
-import { ScrollView, StyleSheet, Text, View } from "react-native";
+import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import { AppHeader } from "@/components/app-header";
@@ -10,81 +12,51 @@ import { FinalRecommendationBar } from "@/components/final-recommendation-bar";
 import { MarketSizeBars } from "@/components/market-size-bars";
 import { type MetricCardProps } from "@/components/metric-card";
 import { MetricsGrid } from "@/components/metrics-grid";
+import { useReportSession } from "@/components/report-session-provider";
 import { ScoreDisplay } from "@/components/score-display";
 import { StrengthsVulnerabilities } from "@/components/strengths-vulnerabilities";
 import { ViewToggle, type ReportView } from "@/components/view-toggle";
 import { tokens } from "@/constants/theme";
-
-const REPORT = {
-  title: "ORBITAL SYNC",
-  description:
-    "High-precision cloud orchestration engine for distributed aerospace telemetry systems. Validated against current market latency and scalability benchmarks.",
-};
-
-const BUILDER_METRICS: MetricCardProps[] = [
-  { label: "OVERALL SCORE", value: "6.8", unit: "/10", progress: 0.68 },
-  { label: "EST. EFFORT", value: "HIGH", valueColor: "ink", subtitle: "~1,200 Engineering Hrs" },
-  {
-    label: "RISK LEVEL",
-    value: "ELEVATED",
-    valueColor: "danger",
-    subtitle: "Data Consistency Hazard",
-  },
-  { label: "MVP TIMELINE", value: "6-8 WKS", valueColor: "ink", subtitle: "To Alpha release" },
-];
-
-const INVESTOR_METRICS: MetricCardProps[] = [
-  {
-    label: "INVESTABILITY SCORE",
-    value: "6.5",
-    unit: "/10",
-    progress: 0.65,
-    icon: "trending-up",
-  },
-  {
-    label: "MARKET SIZE (TAM)",
-    value: "$12B",
-    subtitle: "Global Logistics Segment",
-    icon: "pie-chart-outline",
-  },
-  {
-    label: "DEFENSIBILITY",
-    value: "LOW",
-    valueColor: "ink",
-    subtitle: "Open Source Threats",
-    icon: "shield-outline",
-  },
-  {
-    label: "TRACTION GOAL",
-    value: "10 Pilots",
-    valueColor: "ink",
-    subtitle: "Q4 2024 Milestone",
-    icon: "locate-outline",
-  },
-];
-
-const CONCERNS: Concern[] = [
-  {
-    title: "LOW BARRIER TO ENTRY",
-    description:
-      "Multiple open-source alternatives are emerging in the orbital tracking space, potentially commoditizing the primary feature set.",
-  },
-  {
-    title: "REGULATORY RISK",
-    description:
-      "New space traffic management protocols pending in the EU could require massive architectural changes within 12 months.",
-  },
-  {
-    title: "SALES CYCLE",
-    description:
-      "Initial pilot feedback suggests 18-month sales cycles for Tier 1 satellite operators, exceeding current runway projections.",
-    severity: "info",
-  },
-];
+import {
+  sanitizeReportText,
+  toBuilderMetrics,
+  toConcerns,
+  toInvestorMetrics,
+  toMarketSizeBars,
+} from "@/lib/report-presentation";
+import type { AnalysisPayload } from "@/types/analysis";
 
 export default function ReportsScreen() {
+  const { session } = useReportSession();
   const [view, setView] = useState<ReportView>("builder");
   const [footerHeight, setFooterHeight] = useState(0);
+  const [copied, setCopied] = useState(false);
+
+  if (!session) {
+    return (
+      <SafeAreaView edges={["top"]} style={styles.safeArea}>
+        <AppHeader />
+        <View style={styles.emptyWrap}>
+          <Text style={styles.emptyLabel}>NO REPORT LOADED</Text>
+          <Text style={styles.emptyText}>
+            Run a stress test from the Validate tab to generate a live Builder and Investor report.
+          </Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  const report = session.report;
+  const builderMetrics = toBuilderMetrics(report);
+  const investorMetrics = toInvestorMetrics(report);
+  const concerns = toConcerns(report);
+  const marketBars = toMarketSizeBars(report);
+
+  const handleCopyShareLink = async () => {
+    await Clipboard.setStringAsync(session.shareUrl);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1800);
+  };
 
   return (
     <SafeAreaView edges={["top"]} style={styles.safeArea}>
@@ -103,13 +75,39 @@ export default function ReportsScreen() {
                 <Text style={styles.analysisLabel}>ANALYSIS REPORT</Text>
                 <View style={styles.analysisLine} />
               </View>
-              <Text style={styles.reportTitle}>{REPORT.title}</Text>
-              <Text style={styles.reportDescription}>{REPORT.description}</Text>
+              <Text style={styles.reportTitle}>{sanitizeReportText(report.shared.title)}</Text>
+              <Text style={styles.reportDescription}>
+                {sanitizeReportText(report.shared.description)}
+              </Text>
+
+              <Pressable
+                onPress={handleCopyShareLink}
+                accessibilityRole="button"
+                accessibilityLabel="Copy share report link"
+                style={({ pressed }) => [
+                  styles.shareButton,
+                  pressed ? styles.shareButtonPressed : null,
+                ]}
+              >
+                <Ionicons name="copy-outline" size={14} color={tokens.accent} />
+                <Text style={styles.shareButtonLabel}>
+                  {copied ? "SHARE LINK COPIED" : "COPY SHARE LINK"}
+                </Text>
+              </Pressable>
             </View>
 
             <ViewToggle value={view} onChange={setView} />
 
-            {view === "builder" ? <BuilderView /> : <InvestorView />}
+            {view === "builder" ? (
+              <BuilderView report={report} metrics={builderMetrics} />
+            ) : (
+              <InvestorView
+                report={report}
+                metrics={investorMetrics}
+                concerns={concerns}
+                bars={marketBars}
+              />
+            )}
           </View>
         </ScrollView>
 
@@ -119,8 +117,8 @@ export default function ReportsScreen() {
             style={styles.footerWrap}
           >
             <FinalRecommendationBar
-              primaryLabel="INITIATE_BUILD"
-              secondaryLabel="PROCEED WITH REDUCED SCOPE"
+              primaryLabel={sanitizeReportText(report.builder_view.final_recommendation.primary)}
+              secondaryLabel={sanitizeReportText(report.builder_view.final_recommendation.secondary)}
             />
           </View>
         ) : null}
@@ -129,62 +127,70 @@ export default function ReportsScreen() {
   );
 }
 
-function BuilderView() {
+function BuilderView({
+  report,
+  metrics,
+}: {
+  report: AnalysisPayload;
+  metrics: MetricCardProps[];
+}) {
   return (
     <>
-      <MetricsGrid metrics={BUILDER_METRICS} layout="grid" />
+      <MetricsGrid metrics={metrics} layout="grid" />
 
       <CollapsibleSection number="01" title="PROBLEM CLARITY" defaultOpen>
         <View style={styles.sectionGap}>
           <Text style={styles.bodyText}>
-            The core problem addresses the massive sync latency between ground-station data
-            processing and cloud-based telemetry storage. Current solutions lag by &gt;500ms,
-            whereas Orbital Sync proposes a sub-50ms window using Edge-Native pre-processing.
+            {sanitizeReportText(report.builder_view.problem_clarity.summary)}
           </Text>
 
           <StrengthsVulnerabilities
-            strengths={[
-              "Identifiable high-value bottleneck.",
-              "Clear differentiation from incumbents.",
-            ]}
-            vulnerabilities={[
-              "High dependency on hardware API access.",
-              "Narrow target market (Enterprise focus).",
-            ]}
+            strengths={report.builder_view.problem_clarity.strengths.map(sanitizeReportText)}
+            vulnerabilities={report.builder_view.problem_clarity.vulnerabilities.map(
+              sanitizeReportText,
+            )}
           />
 
-          <ScoreDisplay label="Clarity Score" value="8.5" />
+          <ScoreDisplay
+            label="Clarity Score"
+            value={`${report.builder_view.problem_clarity.clarity_score}`}
+          />
         </View>
       </CollapsibleSection>
 
       <CollapsibleSection number="02" title="TECHNICAL FEASIBILITY">
         <Text style={styles.bodyText}>
-          Edge pre-processing architecture is feasible with existing hardware vendor APIs but
-          requires deep firmware-level optimization.
+          {sanitizeReportText(report.builder_view.technical_feasibility)}
         </Text>
       </CollapsibleSection>
 
       <CollapsibleSection number="03" title="LEARNING VALUE">
-        <Text style={styles.bodyText}>
-          High exposure to distributed systems, satellite telemetry pipelines, and edge compute
-          orchestration.
-        </Text>
+        <Text style={styles.bodyText}>{sanitizeReportText(report.builder_view.learning_value)}</Text>
       </CollapsibleSection>
 
       <CollapsibleSection number="04" title="APPROACHES TO BUILD">
         <Text style={styles.bodyText}>
-          Three viable paths: (1) Lean MVP with sandbox simulator, (2) pilot integration with one
-          Tier-2 partner, (3) full vertical-stack research prototype.
+          {sanitizeReportText(report.builder_view.approaches_to_build)}
         </Text>
       </CollapsibleSection>
     </>
   );
 }
 
-function InvestorView() {
+function InvestorView({
+  report,
+  metrics,
+  concerns,
+  bars,
+}: {
+  report: AnalysisPayload;
+  metrics: MetricCardProps[];
+  concerns: Concern[];
+  bars: { label: string; value: string; width: number }[];
+}) {
   return (
     <>
-      <MetricsGrid metrics={INVESTOR_METRICS} layout="stack" />
+      <MetricsGrid metrics={metrics} layout="stack" />
 
       <CollapsibleSection
         number="1."
@@ -193,25 +199,7 @@ function InvestorView() {
         defaultOpen
       >
         <View style={styles.sectionGap}>
-          <MarketSizeBars
-            bars={[
-              {
-                label: "TAM (TOTAL ADDRESSABLE MARKET)",
-                value: "$12,000,000,000",
-                width: 1.0,
-              },
-              {
-                label: "SAM (SERVICEABLE ADDRESSABLE MARKET)",
-                value: "$4,200,000,000",
-                width: 0.35,
-              },
-              {
-                label: "SOM (SERVICEABLE OBTAINABLE MARKET)",
-                value: "$850,000,000",
-                width: 0.07,
-              },
-            ]}
-          />
+          <MarketSizeBars bars={bars} />
 
           <View style={styles.targetCard}>
             <LinearGradient
@@ -221,7 +209,11 @@ function InvestorView() {
               style={styles.targetGradient}
             >
               <Text style={styles.targetCaption}>TARGET SECTOR</Text>
-              <Text style={styles.targetValue}>ORBITAL LOGISTICS</Text>
+              <Text style={styles.targetValue}>
+                {sanitizeReportText(
+                  report.investor_view.market_size_assessment.target_sector,
+                ).toUpperCase()}
+              </Text>
             </LinearGradient>
           </View>
         </View>
@@ -229,8 +221,7 @@ function InvestorView() {
 
       <CollapsibleSection number="2." title="DEFENSIBILITY MOATS" icon="shield-outline">
         <Text style={styles.bodyText}>
-          Initial moat is technical-differentiation only; patentability of edge sync algorithms is
-          contested.
+          {sanitizeReportText(report.investor_view.defensibility_moats)}
         </Text>
       </CollapsibleSection>
 
@@ -240,18 +231,17 @@ function InvestorView() {
         icon="trending-up-outline"
       >
         <Text style={styles.bodyText}>
-          10 paid pilots within 12 months at $80k-$120k ACV to reach Series-A readiness.
+          {sanitizeReportText(report.investor_view.traction_requirements)}
         </Text>
       </CollapsibleSection>
 
       <CollapsibleSection number="4." title="BUSINESS MODEL" icon="business-outline">
         <Text style={styles.bodyText}>
-          Tiered usage-based pricing with premium SLAs for Tier-1 operators; long-term licensing as
-          upsell.
+          {sanitizeReportText(report.investor_view.business_model)}
         </Text>
       </CollapsibleSection>
 
-      <CriticalConcerns concerns={CONCERNS} />
+      <CriticalConcerns concerns={concerns} />
     </>
   );
 }
@@ -300,6 +290,26 @@ const styles = StyleSheet.create({
     fontSize: 13,
     lineHeight: 18,
   },
+  shareButton: {
+    marginTop: 16,
+    alignSelf: "flex-start",
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    borderWidth: 1,
+    borderColor: tokens.accent,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+  shareButtonPressed: {
+    backgroundColor: "rgba(245, 200, 66, 0.08)",
+  },
+  shareButtonLabel: {
+    color: tokens.accent,
+    fontFamily: "SpaceMono_700Bold",
+    fontSize: 10,
+    letterSpacing: 1.2,
+  },
   footerWrap: {
     position: "absolute",
     left: 0,
@@ -337,5 +347,23 @@ const styles = StyleSheet.create({
     fontFamily: "Inter_900Black",
     fontSize: 22,
     letterSpacing: 0.8,
+  },
+  emptyWrap: {
+    flex: 1,
+    justifyContent: "center",
+    gap: 12,
+    paddingHorizontal: 24,
+  },
+  emptyLabel: {
+    color: tokens.accent,
+    fontFamily: "SpaceMono_700Bold",
+    fontSize: 11,
+    letterSpacing: 1.2,
+  },
+  emptyText: {
+    color: tokens.inkMuted,
+    fontFamily: "Inter_400Regular",
+    fontSize: 14,
+    lineHeight: 22,
   },
 });

--- a/app/(tabs)/reports.tsx
+++ b/app/(tabs)/reports.tsx
@@ -2,7 +2,7 @@ import { Ionicons } from "@expo/vector-icons";
 import * as Clipboard from "expo-clipboard";
 import { LinearGradient } from "expo-linear-gradient";
 import { useState } from "react";
-import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import { AccessibilityInfo, Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import { AppHeader } from "@/components/app-header";
@@ -55,6 +55,7 @@ export default function ReportsScreen() {
   const handleCopyShareLink = async () => {
     await Clipboard.setStringAsync(session.shareUrl);
     setCopied(true);
+    AccessibilityInfo.announceForAccessibility("Share link copied to clipboard.");
     setTimeout(() => setCopied(false), 1800);
   };
 
@@ -83,7 +84,7 @@ export default function ReportsScreen() {
               <Pressable
                 onPress={handleCopyShareLink}
                 accessibilityRole="button"
-                accessibilityLabel="Copy share report link"
+                accessibilityLabel={copied ? "Share link copied" : "Copy share report link"}
                 style={({ pressed }) => [
                   styles.shareButton,
                   pressed ? styles.shareButtonPressed : null,

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -16,6 +16,7 @@ import * as SplashScreen from "expo-splash-screen";
 import { StatusBar } from "expo-status-bar";
 import { useEffect } from "react";
 
+import { ReportSessionProvider } from "@/components/report-session-provider";
 import { tokens } from "@/constants/theme";
 
 SplashScreen.preventAutoHideAsync().catch(() => {});
@@ -44,11 +45,13 @@ export default function RootLayout() {
   if (!loaded && !error) return null;
 
   return (
-    <ThemeProvider value={DarkTheme}>
-      <Stack screenOptions={{ contentStyle: { backgroundColor: tokens.bg } }}>
-        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-      </Stack>
-      <StatusBar style="light" />
-    </ThemeProvider>
+    <ReportSessionProvider>
+      <ThemeProvider value={DarkTheme}>
+        <Stack screenOptions={{ contentStyle: { backgroundColor: tokens.bg } }}>
+          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        </Stack>
+        <StatusBar style="light" />
+      </ThemeProvider>
+    </ReportSessionProvider>
   );
 }

--- a/components/report-session-provider.tsx
+++ b/components/report-session-provider.tsx
@@ -1,0 +1,47 @@
+import { createContext, useContext, useMemo, useState, type ReactNode } from "react";
+
+import { buildPublicReportUrl } from "@/constants/runtime";
+import type { AnalyzeResponse } from "@/types/analysis";
+
+type ReportSession = AnalyzeResponse & {
+  shareUrl: string;
+};
+
+type ReportSessionContextValue = {
+  session: ReportSession | null;
+  setSession: (response: AnalyzeResponse) => void;
+  clearSession: () => void;
+};
+
+const ReportSessionContext = createContext<ReportSessionContextValue | null>(null);
+
+export function ReportSessionProvider({ children }: { children: ReactNode }) {
+  const [session, setSessionState] = useState<ReportSession | null>(null);
+
+  const value = useMemo<ReportSessionContextValue>(
+    () => ({
+      session,
+      setSession: (response) => {
+        setSessionState({
+          ...response,
+          shareUrl: buildPublicReportUrl(response.slug),
+        });
+      },
+      clearSession: () => setSessionState(null),
+    }),
+    [session],
+  );
+
+  return (
+    <ReportSessionContext.Provider value={value}>{children}</ReportSessionContext.Provider>
+  );
+}
+
+export function useReportSession() {
+  const context = useContext(ReportSessionContext);
+  if (!context) {
+    throw new Error("useReportSession must be used within ReportSessionProvider.");
+  }
+
+  return context;
+}

--- a/constants/runtime.ts
+++ b/constants/runtime.ts
@@ -1,0 +1,21 @@
+import Constants from "expo-constants";
+
+type ExtraConfig = {
+  supabaseUrl?: string;
+  supabaseAnonKey?: string;
+  publicReportBaseUrl?: string;
+};
+
+const extra = (Constants.expoConfig?.extra ?? {}) as ExtraConfig;
+
+export const runtimeConfig = {
+  supabaseUrl: extra.supabaseUrl ?? "https://hexcsdactbhdkcmdrnzj.supabase.co",
+  supabaseAnonKey:
+    extra.supabaseAnonKey
+    ?? "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImhleGNzZGFjdGJoZGtjbWRybnpqIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Nzc4MTAzMzcsImV4cCI6MjA5MzM4NjMzN30.0983qPQ-aKankekobLuDG3o5SGEJZdXBkzkOrSOduP0",
+  publicReportBaseUrl: extra.publicReportBaseUrl ?? "https://should-i-build-this.vercel.app",
+} as const;
+
+export function buildPublicReportUrl(slug: string): string {
+  return `${runtimeConfig.publicReportBaseUrl.replace(/\/$/, "")}/r/${slug}`;
+}

--- a/constants/runtime.ts
+++ b/constants/runtime.ts
@@ -9,13 +9,19 @@ type ExtraConfig = {
 const extra = (Constants.expoConfig?.extra ?? {}) as ExtraConfig;
 
 export const runtimeConfig = {
-  supabaseUrl: extra.supabaseUrl ?? "https://hexcsdactbhdkcmdrnzj.supabase.co",
-  supabaseAnonKey:
-    extra.supabaseAnonKey
-    ?? "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImhleGNzZGFjdGJoZGtjbWRybnpqIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Nzc4MTAzMzcsImV4cCI6MjA5MzM4NjMzN30.0983qPQ-aKankekobLuDG3o5SGEJZdXBkzkOrSOduP0",
-  publicReportBaseUrl: extra.publicReportBaseUrl ?? "https://should-i-build-this.vercel.app",
+  supabaseUrl: requireExtraConfig("supabaseUrl", extra.supabaseUrl),
+  supabaseAnonKey: requireExtraConfig("supabaseAnonKey", extra.supabaseAnonKey),
+  publicReportBaseUrl: requireExtraConfig("publicReportBaseUrl", extra.publicReportBaseUrl),
 } as const;
 
 export function buildPublicReportUrl(slug: string): string {
   return `${runtimeConfig.publicReportBaseUrl.replace(/\/$/, "")}/r/${slug}`;
+}
+
+function requireExtraConfig(name: keyof ExtraConfig, value: string | undefined): string {
+  if (!value) {
+    throw new Error(`Missing Expo runtime config: ${name}`);
+  }
+
+  return value;
 }

--- a/lib/analyze-client.ts
+++ b/lib/analyze-client.ts
@@ -1,0 +1,41 @@
+import { runtimeConfig } from "@/constants/runtime";
+import type { AnalyzeRequest, AnalyzeResponse } from "@/types/analysis";
+
+type AnalyzeErrorBody = {
+  error?: string;
+  detail?: string;
+  raw?: string;
+};
+
+export async function invokeAnalyze(
+  payload: AnalyzeRequest,
+  signal?: AbortSignal,
+): Promise<AnalyzeResponse> {
+  const response = await fetch(`${runtimeConfig.supabaseUrl}/functions/v1/analyze`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      apikey: runtimeConfig.supabaseAnonKey,
+    },
+    body: JSON.stringify(payload),
+    signal,
+  });
+
+  const json = (await response.json().catch(() => null)) as AnalyzeResponse | AnalyzeErrorBody | null;
+
+  if (!response.ok) {
+    const errorBody = isAnalyzeErrorBody(json) ? json : null;
+    const detail = errorBody ? [errorBody.error, errorBody.detail].filter(Boolean).join(" ") : "";
+    throw new Error(detail || "Analysis request failed.");
+  }
+
+  if (!json || typeof json !== "object" || !("slug" in json) || !("report" in json)) {
+    throw new Error("Analysis response was malformed.");
+  }
+
+  return json as AnalyzeResponse;
+}
+
+function isAnalyzeErrorBody(value: unknown): value is AnalyzeErrorBody {
+  return !!value && typeof value === "object" && ("error" in value || "detail" in value);
+}

--- a/lib/analyze-client.ts
+++ b/lib/analyze-client.ts
@@ -25,8 +25,7 @@ export async function invokeAnalyze(
 
   if (!response.ok) {
     const errorBody = isAnalyzeErrorBody(json) ? json : null;
-    const detail = errorBody ? [errorBody.error, errorBody.detail].filter(Boolean).join(" ") : "";
-    throw new Error(detail || "Analysis request failed.");
+    throw new Error(getUserFacingAnalyzeError(errorBody));
   }
 
   if (!json || typeof json !== "object" || !("slug" in json) || !("report" in json)) {
@@ -38,4 +37,30 @@ export async function invokeAnalyze(
 
 function isAnalyzeErrorBody(value: unknown): value is AnalyzeErrorBody {
   return !!value && typeof value === "object" && ("error" in value || "detail" in value);
+}
+
+function getUserFacingAnalyzeError(errorBody: AnalyzeErrorBody | null): string {
+  const message = `${errorBody?.error ?? ""} ${errorBody?.detail ?? ""}`.toLowerCase();
+
+  if (message.includes("ideaText is required".toLowerCase())) {
+    return "Enter your idea before running the stress test.";
+  }
+
+  if (message.includes("invalid json")) {
+    return "The request payload was invalid. Try again.";
+  }
+
+  if (message.includes("anthropic")) {
+    return "The analysis engine had a temporary issue. Try again in a moment.";
+  }
+
+  if (message.includes("failed to save report")) {
+    return "The report was generated, but saving it failed. Try again.";
+  }
+
+  if (message.includes("missing required environment configuration")) {
+    return "The backend is not configured correctly right now.";
+  }
+
+  return "The stress test failed. Try again.";
 }

--- a/lib/report-presentation.ts
+++ b/lib/report-presentation.ts
@@ -25,7 +25,7 @@ export function toBuilderMetrics(report: AnalysisPayload): MetricCardProps[] {
       label: "EST. EFFORT",
       value: builder.estimated_effort,
       valueColor: "ink",
-      subtitle: sanitizeReportText(builder.learning_value),
+      subtitle: summarizeEffort(builder.estimated_effort),
     },
     {
       label: "RISK LEVEL",
@@ -80,7 +80,7 @@ export function toMarketSizeBars(report: AnalysisPayload) {
   const market = report.investor_view.market_size_assessment;
   const parsed = [market.tam, market.sam, market.som].map(parseMagnitude);
 
-  let widths: number[] = [...DEFAULT_BAR_WIDTHS];
+  let widths: number[] = [0.34, 0.34, 0.34];
   if (parsed.every((value) => value !== null) && parsed[0] && parsed[0] > 0) {
     widths = parsed.map((value) => clamp01((value ?? 0) / parsed[0]));
   }
@@ -131,6 +131,12 @@ function summarizeDefensibility(value: string): string {
   if (upper.includes("MODERATE")) return "MODERATE";
   if (upper.includes("HIGH")) return "HIGH";
   return upper.slice(0, 18) || "UNCLEAR";
+}
+
+function summarizeEffort(value: AnalysisPayload["builder_view"]["estimated_effort"]): string {
+  if (value === "HIGH") return "HEAVY EXECUTION LOAD";
+  if (value === "MEDIUM") return "MODERATE BUILD SCOPE";
+  return "LEAN MVP FRIENDLY";
 }
 
 function compactMarketValue(primary: string, fallback: string): string {

--- a/lib/report-presentation.ts
+++ b/lib/report-presentation.ts
@@ -1,0 +1,155 @@
+import type { Concern } from "@/components/critical-concerns";
+import type { MetricCardProps } from "@/components/metric-card";
+import type { AnalysisPayload } from "@/types/analysis";
+
+const DEFAULT_BAR_WIDTHS = [1, 0.35, 0.07] as const;
+
+export function sanitizeReportText(input: string): string {
+  return input
+    .replace(/<cite[^>]*>.*?<\/cite>/gi, "")
+    .replace(/\s{2,}/g, " ")
+    .trim();
+}
+
+export function toBuilderMetrics(report: AnalysisPayload): MetricCardProps[] {
+  const builder = report.builder_view;
+
+  return [
+    {
+      label: "OVERALL SCORE",
+      value: formatScore(builder.overall_score),
+      unit: "/10",
+      progress: clamp01(builder.overall_score / 10),
+    },
+    {
+      label: "EST. EFFORT",
+      value: builder.estimated_effort,
+      valueColor: "ink",
+      subtitle: sanitizeReportText(builder.learning_value),
+    },
+    {
+      label: "RISK LEVEL",
+      value: builder.risk_level,
+      valueColor: isHighRisk(builder.risk_level) ? "danger" : "ink",
+      subtitle: sanitizeReportText(builder.technical_feasibility),
+    },
+    {
+      label: "MVP TIMELINE",
+      value: builder.mvp_timeline.toUpperCase(),
+      valueColor: "ink",
+      subtitle: "TARGET DELIVERY WINDOW",
+    },
+  ];
+}
+
+export function toInvestorMetrics(report: AnalysisPayload): MetricCardProps[] {
+  const investor = report.investor_view;
+
+  return [
+    {
+      label: "INVESTABILITY SCORE",
+      value: formatScore(investor.investability_score),
+      unit: "/10",
+      progress: clamp01(investor.investability_score / 10),
+      icon: "trending-up",
+    },
+    {
+      label: "MARKET SIZE (TAM)",
+      value: compactMarketValue(investor.market_size_assessment.tam, investor.market_size_tam),
+      subtitle: sanitizeReportText(investor.market_size_tam),
+      icon: "pie-chart-outline",
+    },
+    {
+      label: "DEFENSIBILITY",
+      value: summarizeDefensibility(investor.defensibility),
+      valueColor: "ink",
+      subtitle: sanitizeReportText(investor.defensibility),
+      icon: "shield-outline",
+    },
+    {
+      label: "TRACTION GOAL",
+      value: sanitizeReportText(investor.traction_goal),
+      valueColor: "ink",
+      subtitle: sanitizeReportText(investor.traction_requirements),
+      icon: "locate-outline",
+    },
+  ];
+}
+
+export function toMarketSizeBars(report: AnalysisPayload) {
+  const market = report.investor_view.market_size_assessment;
+  const parsed = [market.tam, market.sam, market.som].map(parseMagnitude);
+
+  let widths: number[] = [...DEFAULT_BAR_WIDTHS];
+  if (parsed.every((value) => value !== null) && parsed[0] && parsed[0] > 0) {
+    widths = parsed.map((value) => clamp01((value ?? 0) / parsed[0]));
+  }
+
+  return [
+    {
+      label: "TAM (TOTAL ADDRESSABLE MARKET)",
+      value: sanitizeReportText(market.tam),
+      width: widths[0],
+    },
+    {
+      label: "SAM (SERVICEABLE ADDRESSABLE MARKET)",
+      value: sanitizeReportText(market.sam),
+      width: widths[1],
+    },
+    {
+      label: "SOM (SERVICEABLE OBTAINABLE MARKET)",
+      value: sanitizeReportText(market.som),
+      width: widths[2],
+    },
+  ];
+}
+
+export function toConcerns(report: AnalysisPayload): Concern[] {
+  return report.investor_view.critical_concerns.map((concern) => ({
+    title: sanitizeReportText(concern.title).toUpperCase(),
+    description: sanitizeReportText(concern.description),
+    severity: concern.severity,
+  }));
+}
+
+function formatScore(value: number): string {
+  return Number.isInteger(value) ? `${value}` : value.toFixed(1);
+}
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+function isHighRisk(level: AnalysisPayload["builder_view"]["risk_level"]): boolean {
+  return level === "ELEVATED" || level === "HIGH";
+}
+
+function summarizeDefensibility(value: string): string {
+  const upper = sanitizeReportText(value).toUpperCase();
+  if (upper.includes("WEAK")) return "WEAK";
+  if (upper.includes("LOW")) return "LOW";
+  if (upper.includes("MODERATE")) return "MODERATE";
+  if (upper.includes("HIGH")) return "HIGH";
+  return upper.slice(0, 18) || "UNCLEAR";
+}
+
+function compactMarketValue(primary: string, fallback: string): string {
+  const source = sanitizeReportText(primary || fallback);
+  const match = source.match(/\$[\d.,]+(?:\s?[BMK]|(?:\s?billion|\s?million|\s?thousand))?/i);
+  return match?.[0]?.toUpperCase() ?? source.slice(0, 18).toUpperCase();
+}
+
+function parseMagnitude(value: string): number | null {
+  const match = sanitizeReportText(value).match(/\$?\s*([\d.,]+)\s*([BMK]|billion|million|thousand)?/i);
+  if (!match) return null;
+
+  const amount = Number(match[1].replace(/,/g, ""));
+  if (!Number.isFinite(amount)) return null;
+
+  const suffix = match[2]?.toLowerCase();
+  if (!suffix) return amount;
+  if (suffix === "b" || suffix === "billion") return amount * 1_000_000_000;
+  if (suffix === "m" || suffix === "million") return amount * 1_000_000;
+  if (suffix === "k" || suffix === "thousand") return amount * 1_000;
+  return amount;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@react-navigation/elements": "^2.6.3",
         "@react-navigation/native": "^7.1.8",
         "expo": "~54.0.33",
+        "expo-clipboard": "~8.0.8",
         "expo-constants": "~18.0.13",
         "expo-font": "~14.0.11",
         "expo-haptics": "~15.0.8",
@@ -6238,6 +6239,17 @@
         "@expo/image-utils": "^0.8.8",
         "expo-constants": "~18.0.13"
       },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-clipboard": {
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/expo-clipboard/-/expo-clipboard-8.0.8.tgz",
+      "integrity": "sha512-VKoBkHIpZZDJTB0jRO4/PZskHdMNOEz3P/41tmM6fDuODMpqhvyWK053X0ebspkxiawJX9lX33JXHBCvVsTTOA==",
+      "license": "MIT",
       "peerDependencies": {
         "expo": "*",
         "react": "*",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
     "expo": "~54.0.33",
+    "expo-clipboard": "~8.0.8",
     "expo-constants": "~18.0.13",
     "expo-font": "~14.0.11",
     "expo-haptics": "~15.0.8",

--- a/types/analysis.ts
+++ b/types/analysis.ts
@@ -1,0 +1,58 @@
+export type Severity = "warn" | "info";
+
+export type AnalysisPayload = {
+  builder_view: {
+    overall_score: number;
+    estimated_effort: "LOW" | "MEDIUM" | "HIGH";
+    risk_level: "LOW" | "MODERATE" | "ELEVATED" | "HIGH";
+    mvp_timeline: string;
+    problem_clarity: {
+      summary: string;
+      strengths: string[];
+      vulnerabilities: string[];
+      clarity_score: number;
+    };
+    technical_feasibility: string;
+    learning_value: string;
+    approaches_to_build: string;
+    final_recommendation: {
+      primary: string;
+      secondary: string;
+    };
+  };
+  investor_view: {
+    investability_score: number;
+    market_size_tam: string;
+    defensibility: string;
+    traction_goal: string;
+    market_size_assessment: {
+      tam: string;
+      sam: string;
+      som: string;
+      target_sector: string;
+    };
+    defensibility_moats: string;
+    traction_requirements: string;
+    business_model: string;
+    critical_concerns: Array<{
+      title: string;
+      description: string;
+      severity: Severity;
+    }>;
+  };
+  shared: {
+    title: string;
+    description: string;
+  };
+};
+
+export type AnalyzeRequest = {
+  ideaText: string;
+  backgroundText: string;
+};
+
+export type AnalyzeResponse = {
+  slug: string;
+  report: AnalysisPayload;
+  model: string;
+};


### PR DESCRIPTION
## Summary
- connect the Validate tab to the live Supabase /analyze Edge Function with anonymous app-side invocation and inline error handling
- add an app-level report session store so the loading flow hands real analysis data to the Reports tab
- replace the hardcoded report screen content with transformed Builder/Investor analysis data and add copy-share link support

## Verification
- 
pm.cmd run typecheck
- 
pm.cmd run lint -- --no-cache
- 
px.cmd expo export --platform web
- successful live anonymous POST to https://hexcsdactbhdkcmdrnzj.supabase.co/functions/v1/analyze after app integration

Closes #7